### PR TITLE
Move compose runtime dependency to JS source set

### DIFF
--- a/app/default/site/build.gradle.kts.ftl
+++ b/app/default/site/build.gradle.kts.ftl
@@ -24,11 +24,12 @@ kotlin {
     configAsKobwebApplication("${projectName}" /*, includeServer = true*/)
 
     sourceSets {
-        commonMain.dependencies {
-            implementation(libs.compose.runtime)
-        }
+//        commonMain.dependencies {
+//          // Uncomment and add shared dependencies between JS and JVM here if building a fullstack app
+//        }
 
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             implementation(libs.kobweb.silk)

--- a/app/default/site/build.gradle.kts.ftl
+++ b/app/default/site/build.gradle.kts.ftl
@@ -25,7 +25,7 @@ kotlin {
 
     sourceSets {
 //        commonMain.dependencies {
-//          // Uncomment and add shared dependencies between JS and JVM here if building a fullstack app
+//          // Add shared dependencies between JS and JVM here if building a fullstack app
 //        }
 
         jsMain.dependencies {

--- a/app/empty/site/build.gradle.kts.ftl
+++ b/app/empty/site/build.gradle.kts.ftl
@@ -22,11 +22,13 @@ kotlin {
     configAsKobwebApplication("${projectName}"<#if useServer?boolean>, includeServer = true</#if>)
 
     sourceSets {
+        <#if useServer?boolean>
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
+            // Add shared dependencies between JS and JVM here
         }
-
+        </#if>
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             <#if !useSilk?boolean>// </#if>implementation(libs.kobweb.silk)

--- a/app/empty/site/build.gradle.kts.ftl
+++ b/app/empty/site/build.gradle.kts.ftl
@@ -23,9 +23,9 @@ kotlin {
 
     sourceSets {
         <#if useServer?boolean>
-        commonMain.dependencies {
-            // Add shared dependencies between JS and JVM here
-        }
+//        commonMain.dependencies {
+//          // Add shared dependencies between JS and JVM here
+//        }
         </#if>
         jsMain.dependencies {
             implementation(libs.compose.runtime)

--- a/examples/chat/auth/build.gradle.kts
+++ b/examples/chat/auth/build.gradle.kts
@@ -15,11 +15,11 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
             implementation(libs.kotlinx.serialization.json)
             implementation(project(":core"))
         }
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             implementation(libs.kobweb.silk)

--- a/examples/chat/chat/build.gradle.kts
+++ b/examples/chat/chat/build.gradle.kts
@@ -15,12 +15,12 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
             implementation(libs.kotlinx.serialization.json)
             implementation(project(":core"))
             implementation(project(":auth"))
         }
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             implementation(libs.kobweb.silk)

--- a/examples/chat/core/build.gradle.kts
+++ b/examples/chat/core/build.gradle.kts
@@ -16,10 +16,8 @@ kotlin {
     configAsKobwebLibrary(includeServer = true)
 
     sourceSets {
-        commonMain.dependencies {
-            implementation(libs.compose.runtime)
-        }
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             implementation(libs.kobweb.silk)

--- a/examples/chat/site/build.gradle.kts
+++ b/examples/chat/site/build.gradle.kts
@@ -14,12 +14,12 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
             implementation(project(":core"))
             implementation(project(":auth"))
             implementation(project(":chat"))
         }
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             implementation(libs.kobweb.silk)

--- a/examples/imageprocessor/util/build.gradle.kts
+++ b/examples/imageprocessor/util/build.gradle.kts
@@ -11,6 +11,5 @@ kotlin {
     sourceSets {
         jsMain.dependencies {
         }
-
     }
 }

--- a/examples/todo/site/build.gradle.kts
+++ b/examples/todo/site/build.gradle.kts
@@ -15,11 +15,11 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
             implementation(libs.kotlinx.serialization.json)
         }
 
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             implementation(libs.kobweb.silk)

--- a/library/sitelib/build.gradle.kts.ftl
+++ b/library/sitelib/build.gradle.kts.ftl
@@ -15,9 +15,9 @@ kotlin {
 
     sourceSets {
         <#if useServer?boolean>
-        commonMain.dependencies {
-            // Add shared dependencies between JS and JVM here
-        }
+//        commonMain.dependencies {
+//          // Add shared dependencies between JS and JVM here
+//        }
         </#if>
         jsMain.dependencies {
             implementation(libs.compose.runtime)

--- a/library/sitelib/build.gradle.kts.ftl
+++ b/library/sitelib/build.gradle.kts.ftl
@@ -14,11 +14,13 @@ kotlin {
     configAsKobwebLibrary(<#if useServer?boolean>includeServer = true</#if>)
 
     sourceSets {
+        <#if useServer?boolean>
         commonMain.dependencies {
-            implementation(libs.compose.runtime)
+            // Add shared dependencies between JS and JVM here
         }
-
+        </#if>
         jsMain.dependencies {
+            implementation(libs.compose.runtime)
             implementation(libs.compose.html.core)
             implementation(libs.kobweb.core)
             <#if !useSilk?boolean>// </#if>implementation(libs.kobweb.silk)


### PR DESCRIPTION
This is possible now that Kobweb excludes the compose compiler plugin from the JVM source set by default.