### PR TITLE
Fix 'AppEntry.kt Surface' to fill height using minHeight instead of fillMaxHeight

### DIFF
--- a/app/default/site/src/site/AppEntry.kt.ftl
+++ b/app/default/site/src/site/AppEntry.kt.ftl
@@ -42,8 +42,7 @@ fun AppEntry(content: @Composable () -> Unit) {
         LaunchedEffect(colorMode) {
             colorMode.saveToLocalStorage(COLOR_MODE_KEY)
         }
-
-        Surface(SmoothColorStyle.toModifier().minHeight(100.percent)) {
+        Surface(SmoothColorStyle.toModifier().minHeight(100.vh)) {
             content()
         }
     }

--- a/app/default/site/src/site/AppEntry.kt.ftl
+++ b/app/default/site/src/site/AppEntry.kt.ftl
@@ -43,7 +43,7 @@ fun AppEntry(content: @Composable () -> Unit) {
             colorMode.saveToLocalStorage(COLOR_MODE_KEY)
         }
 
-        Surface(SmoothColorStyle.toModifier().fillMaxHeight()) {
+        Surface(SmoothColorStyle.toModifier().minHeight(100.percent)) {
             content()
         }
     }


### PR DESCRIPTION
In this template, the min-height isn't necessary by default because `PageLayout` already has `minHeigh(100.vh)`, but if the user removes layout, the Surface should still fix the height


```diff
@App
@Composable
fun AppEntry(content: @Composable () -> Unit) {
    SilkApp {
        val colorMode = ColorMode.current
        LaunchedEffect(colorMode) {
            colorMode.saveToLocalStorage(COLOR_MODE_KEY)
        }
-       Surface(SmoothColorStyle.toModifier().fillMaxHeight())
+        Surface(SmoothColorStyle.toModifier().minHeight(100.percent))
 {
            content()
        }
    }
}
```