### PR TITLE
Fix link to blog post in About.md

### DIFF
--- a/app/default/site/resources/markdown/About.md
+++ b/app/default/site/resources/markdown/About.md
@@ -117,5 +117,5 @@ $ kobweb run --layout static --env prod
 If you're satisfied, you can upload your site files to the static website host provider of your choice. Each provider
 has its own instructions for how it discovers your files, so please refer to their documentation.
 
-You can [read this blog post](https://bitspittle.dev/blog/2022/staticdeploy) for some concrete examples of exporting a
+You can [read this blog post](https://bitspittle.dev/blog/2022/static-deploy) for some concrete examples of exporting a
 Kobweb site to two popular static website hosting providers.


### PR DESCRIPTION
A simple fix of a broken link I discovered while looking at the content produced by the `kobweb create app` command.

Btw, thanks for Kobweb (and related utilities), I just discovered your work and I'm excited to try it on various project 🙂 